### PR TITLE
KR-1886: Upgrade mongoose to latest

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,7 @@ version: '3.2'
 services:
 
   mongo:
-    image: mongo:3.4.16
-    # image: mongo:3.6
+    image: mongo:3.6
     restart: always
     command: --smallfiles
     expose:

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "hooks": "~0.3.2",
     "minimatch": "~1.0.0",
     "moment": "~2.6.0",
-    "mongoose": "~4.9.1",
+    "mongoose": "~5.6.9",
     "q": "~1.5.0",
     "underscore": "~1.5.2"
   },

--- a/test/bulkpost.coffee
+++ b/test/bulkpost.coffee
@@ -118,8 +118,8 @@ describe 'Bulk Post', ->
 				res.body[0].state.should.equal('fulfilled')
 				res.body[1].state.should.equal('rejected')
 				res.body[2].state.should.equal('rejected')
-				res.body[1].reason.message.message.should.equal('Post validation failed')
-				res.body[2].reason.message.message.should.equal('Post validation failed')
+				res.body[1].reason.message.message.should.equal('Post validation failed: string: Path `string` is required.')
+				res.body[2].reason.message.message.should.equal('Post validation failed: string: Path `string` is required.')
 				done()
 
 		it 'should have the first error code if they are all errors', (done) ->


### PR DESCRIPTION
The latest version of mongoose is compatible with mongo 3.6 and our current version 3.4, so it should be safe to update now.

The only difference that the unit tests picked up was in error messaging -- I didn't find any usages of the old string in maxwell-edi so it should be okay.

https://mongoosejs.com/docs/compatibility.html